### PR TITLE
Corret CFSSLURL

### DIFF
--- a/tools/deployment/common/setup-certificates.sh
+++ b/tools/deployment/common/setup-certificates.sh
@@ -16,7 +16,7 @@
 set -xe
 
 CURRENT_DIR=$(pwd)
-CFSSLURL=https://pkg.cfssl.org/R1.2
+CFSSLURL=https://pkg.cfssl.org
 
 TDIR=/tmp/certs
 rm -rf $TDIR


### PR DESCRIPTION
Small fix in url for cfssl. Change to  CFSSLURL=https://pkg.cfssl.org