### PR TITLE
Mount all the volumes configured in values.yaml under ironic conductor container.

### DIFF
--- a/ironic/templates/statefulset-conductor.yaml
+++ b/ironic/templates/statefulset-conductor.yaml
@@ -194,6 +194,7 @@ spec:
               mountPath: /sys
             - name: pod-data
               mountPath: /var/lib/openstack-helm
+{{ if $mounts_ironic_conductor.volumeMounts }}{{ toYaml $mounts_ironic_conductor.volumeMounts | indent 12 }}{{ end }}
         - name: ironic-conductor-pxe
 {{ tuple $envAll "ironic_pxe" | include "helm-toolkit.snippets.image" | indent 10 }}
 {{ tuple $envAll $envAll.Values.pod.resources.conductor | include "helm-toolkit.snippets.kubernetes_resources" | indent 10 }}


### PR DESCRIPTION
At the moment, there is no way to configure in the helm chart additional volumes to be mounted to ironic-conductor container. In this implementation, we just mount the volumes that are also mounted in ironic-conductor-http container.

In the future we might separate this, but for the moment I think it is good enough.