### PR TITLE
Support for Neutron Helm test cleanup and reset for abnormal failures

### DIFF
--- a/neutron/templates/bin/_neutron-cleanup.sh.tpl
+++ b/neutron/templates/bin/_neutron-cleanup.sh.tpl
@@ -1,0 +1,5 @@
+set -ex
+
+ospurge --purge-project $OS_TEST_PROJECT_NAME
+
+openstack quota set $OS_TEST_PROJECT_NAME --networks $NETWORK_QUOTA --ports $PORT_QUOTA --routers $ROUTER_QUOTA --subnets $SUBNET_QUOTA --secgroups $SEC_GROUP_QUOTA

--- a/neutron/templates/configmap-bin.yaml
+++ b/neutron/templates/configmap-bin.yaml
@@ -81,4 +81,6 @@ data:
 {{ tuple "bin/_neutron-server.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
   rabbit-init.sh: |
 {{- include "helm-toolkit.scripts.rabbit_init" . | indent 4 }}
+  neutron-cleanup.sh: |
+{{ tuple "bin/_neutron-cleanup.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
 {{- end }}

--- a/neutron/templates/pod-rally-test.yaml
+++ b/neutron/templates/pod-rally-test.yaml
@@ -64,6 +64,43 @@ spec:
         - name: SERVICE_OS_ROLE
           value: {{ .Values.endpoints.identity.auth.test.role | quote }}
   containers:
+    - name: {{ .Release.Name }}-reset
+      image: python
+      env:
+{{- with $env := dict "ksUserSecret" .Values.secrets.identity.admin }}
+{{- include "helm-toolkit.snippets.keystone_openrc_env_vars" $env | indent 8 }}
+{{- end }}
+{{- with $env := dict "ksUserSecret" .Values.secrets.identity.test }}
+{{- include "helm-toolkit.snippets.keystone_user_create_env_vars" $env | indent 8 }}
+{{- end }}
+        - name: http_proxy
+          value: {{ .Values.proxies.http_proxy }}
+        - name: https_proxy
+          value: {{ .Values.proxies.https_proxy }}
+        - name: no_proxy
+          value: {{ .Values.proxies.no_proxy }}
+        - name: OS_TEST_PROJECT_NAME
+          value: {{ .Values.endpoints.identity.auth.test.project_name }}
+        - name: NETWORK_QUOTA
+          value: {{ (first (index .Values.conf.rally_tests.tests "NeutronNetworks.create_and_delete_networks")).context.quotas.neutron.network | quote }}
+        - name: PORT_QUOTA
+          value: {{ (first (index .Values.conf.rally_tests.tests "NeutronNetworks.create_and_delete_ports")).context.quotas.neutron.port | quote }}
+        - name: ROUTER_QUOTA
+          value: {{ (first (index .Values.conf.rally_tests.tests "NeutronNetworks.create_and_delete_routers")).context.quotas.neutron.router | quote }}
+        - name: SUBNET_QUOTA
+          value: {{ (first (index .Values.conf.rally_tests.tests "NeutronNetworks.create_and_delete_subnets")).context.quotas.neutron.subnet | quote }}
+        - name: SEC_GROUP_QUOTA
+          value: {{ (first (index .Values.conf.rally_tests.tests "NeutronSecurityGroup.create_and_list_security_groups")).context.quotas.neutron.security_group | quote }}
+      command: ["/bin/bash", "-c", "pip install ospurge; pip install openstackclient"]
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/bash", "-c", "sh /tmp/neutron-cleanup.sh"]
+      volumeMounts:
+        - name: neutron-bin
+          mountPath: /tmp/neutron-cleanup.sh
+          subPath: neutron-cleanup.sh
+          readOnly: true
     - name: {{ .Release.Name }}-test
 {{ tuple $envAll "test" | include "helm-toolkit.snippets.image" | indent 6 }}
 {{ tuple $envAll $envAll.Values.pod.resources.jobs.tests | include "helm-toolkit.snippets.kubernetes_resources" | indent 6 }}

--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -2260,3 +2260,8 @@ manifests:
   secret_rabbitmq: true
   service_ingress_server: true
   service_server: true
+  
+proxies:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""


### PR DESCRIPTION
Rally usually cleans up all its resources in normal executions - normal test success cases and normal test failure cases. But the generic cleanup does not work well for out of the system failures like process interruptions, pod failures, disaster cleanup etc. This is a known issue in rally-openstack. - "Current generic mechanism is nice but it doesn't work enough well in real life. And in cases of existing users, persistence context and disaster cleanups it doesn't work well."

Hence, if we shall face above such issues, it is becoming impossible to run "helm test neutron" again because of the stale data and different quota limits mentioned in the values.yaml. Hence we need to purge the stale data from the "test" project as well as reset the quota limit for such scenarios.

For the normal executions, this patch has to do nothing, but for unexpected failures, this patch will purge the stale data from test project and reset the quota as defined in values.yaml for the next run.