### PR TITLE
Change serviceAccountName value from job-bootstrap.yaml

### DIFF
--- a/nova/templates/job-bootstrap.yaml
+++ b/nova/templates/job-bootstrap.yaml
@@ -21,7 +21,7 @@ limitations under the License.
 {{- $configFile := printf "/etc/%s/%s.conf" $serviceName $serviceName -}}
 {{- $logConfigFile := $envAll.Values.conf.nova.DEFAULT.log_config_append -}}
 {{- $nodeSelector := index . "nodeSelector" | default ( dict $envAll.Values.labels.job.node_selector_key $envAll.Values.labels.job.node_selector_value ) -}}
-{{- $serviceAccountName := printf "%s-%s" $serviceName "bootstrap" -}}
+{{- $serviceAccountName := printf "%s-%s" .Release.Name "bootstrap" -}}
 {{ tuple $envAll "bootstrap" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
 ---
 apiVersion: batch/v1


### PR DESCRIPTION
Change the serviceAccountName value, which is used to ClusterRole name, in order to be able to deploy multiples nova charts in different kubernetes namespace