### PR TITLE
Horizon fix after Django upgrade

### DIFF
--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -232,7 +232,10 @@ conf:
       template: |
         import os
 
-        from django.utils.translation import ugettext_lazy as _
+        try:
+            from django.utils.translation import ugettext_lazy as _
+        except ImportError:
+            from django.utils.translation import gettext_lazy as _
 
         from openstack_dashboard import exceptions
 


### PR DESCRIPTION
Django 4.0 doesn't have `ugettext_lazy` anymore and container crashed immediately due to unability to load this function.

See: https://storyboard.openstack.org/#!/story/2011130