### PR TITLE
Horizon django upgrade

### DIFF
--- a/horizon/templates/bin/_django.wsgi.tpl
+++ b/horizon/templates/bin/_django.wsgi.tpl
@@ -23,7 +23,7 @@ import sys
 
 import pymysql
 
-pymysql.version_info = (1, 4, 0, "final", 0)
+pymysql.version_info = (1, 4, 3, "final", 0)
 pymysql.install_as_MySQLdb()
 
 from django.core.wsgi import get_wsgi_application

--- a/horizon/templates/bin/_manage.py.tpl
+++ b/horizon/templates/bin/_manage.py.tpl
@@ -23,7 +23,7 @@ import os
 import sys
 
 import pymysql
-pymysql.version_info = (1, 4, 0, "final", 0)
+pymysql.version_info = (1, 4, 3, "final", 0)
 pymysql.install_as_MySQLdb()
 
 from django.core.management import execute_from_command_line

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -262,7 +262,10 @@ conf:
       template: |
         import os
 
-        from django.utils.translation import ugettext_lazy as _
+        try:
+            from django.utils.translation import ugettext_lazy as _
+        except ImportError:
+            from django.utils.translation import gettext_lazy as _
 
         from openstack_dashboard import exceptions
 

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -397,7 +397,7 @@ conf:
 
         CACHES = {
             'default': {
-                'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+                'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
                 'LOCATION': '{{ tuple "oslo_cache" "internal" "memcache" . | include "helm-toolkit.endpoints.host_and_port_endpoint_uri_lookup" }}',
             }
         }


### PR DESCRIPTION
Fixes Horizon after Django upgrade under the hood.

Tested with 2024.1 release with step-by-step official documentation at https://docs.openstack.org/openstack-helm/latest/install/openstack.html which was unable to complete due to those errors.