### PR TITLE
fix(manila): add processes count to manila_api_uwsgi

### DIFF
--- a/manila/values.yaml
+++ b/manila/values.yaml
@@ -852,6 +852,7 @@ conf:
               max: 0
   manila_api_uwsgi:
     uwsgi:
+      processes: 1
       add-header: "Connection: close"
       buffer-size: 65535
       die-on-term: true


### PR DESCRIPTION
The **manil-api** pod uwsgi config does not have 'processes' feild so pod is not running