### PR TITLE
feat: allow for overrides to octavia rbac policies

### DIFF
--- a/octavia/templates/configmap-etc.yaml
+++ b/octavia/templates/configmap-etc.yaml
@@ -132,6 +132,7 @@ data:
   octavia.conf: {{ include "helm-toolkit.utils.to_oslo_conf" .Values.conf.octavia | b64enc }}
   octavia-api-uwsgi.ini: {{ include "helm-toolkit.utils.to_oslo_conf" .Values.conf.octavia_api_uwsgi | b64enc }}
   logging.conf: {{ include "helm-toolkit.utils.to_oslo_conf" .Values.conf.logging | b64enc }}
+  policy.yaml: {{ toYaml .Values.conf.policy | b64enc }}
 {{- end }}
 {{- end }}
 

--- a/octavia/templates/deployment-api.yaml
+++ b/octavia/templates/deployment-api.yaml
@@ -108,6 +108,10 @@ spec:
               mountPath: /etc/octavia/octavia-api-uwsgi.ini
               subPath: octavia-api-uwsgi.ini
               readOnly: true
+            - name: octavia-etc
+              mountPath: /etc/octavia/policy.yaml
+              subPath: policy.yaml
+              readOnly: true
             {{- if .Values.conf.octavia.DEFAULT.log_config_append }}
             - name: octavia-etc
               mountPath: {{ .Values.conf.octavia.DEFAULT.log_config_append }}

--- a/octavia/values.yaml
+++ b/octavia/values.yaml
@@ -268,6 +268,8 @@ conf:
       rpc_thread_pool_size: 2
     oslo_messaging_notifications:
       driver: messagingv2
+    oslo_policy:
+      policy_file: /etc/octavia/policy.yaml
     house_keeping:
       load_balancer_expiry_age: 3600
       amphora_expiry_age: 3600
@@ -278,6 +280,7 @@ conf:
       memcache_security_strategy: ENCRYPT
     task_flow:
       jobboard_enabled: true
+  policy: {}
   logging:
     loggers:
       keys:


### PR DESCRIPTION
The octavia helm chart currently does not allow for the modificaiton of rbac (policy.yaml).  To addext rbac changes, we need to create the policy.yaml file in the octavia directory.  The through a helm override, we can affect rbac changes by setting the conf->policy stanza.